### PR TITLE
Skip pools with missing update accounts

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -199,11 +199,7 @@ fn main() {
         let accounts = connection.get_multiple_accounts(token_addr_chunk).unwrap();
         update_accounts.push(accounts);
     }
-    let mut update_accounts = update_accounts
-        .concat()
-        .into_iter()
-        .filter(|s| s.is_some())
-        .collect::<Vec<Option<Account>>>();
+    let mut update_accounts = update_accounts.concat();
 
     info!("update accounts is {:?}", update_accounts.len());
     // slide it out here
@@ -221,13 +217,23 @@ fn main() {
     let mut pool_count = 0;
     let mut account_ptr = 0;
 
-    for pool in pools.into_iter() {
+    for mut pool in pools.into_iter() {
         // update pool
         let length = update_pks_lengths[pool_count];
-        let _account_slice = &update_accounts[account_ptr..account_ptr + length].to_vec();
+        if account_ptr + length > update_accounts.len() {
+            warn!(
+                "skipping pool {}: expected {} update accounts, only {} remain",
+                pool.get_name(),
+                length,
+                update_accounts.len().saturating_sub(account_ptr),
+            );
+            pool_count += 1;
+            continue;
+        }
+        let account_slice = update_accounts[account_ptr..account_ptr + length].to_vec();
         account_ptr += length;
 
-        // pool.set_update_accounts(*account_slice);
+        pool.set_update_accounts(account_slice, cluster.clone());
 
         // add pool to graph
         let idxs = &all_mint_idxs[pool_count * 2..(pool_count + 1) * 2].to_vec();

--- a/client/src/pools/aldrin.rs
+++ b/client/src/pools/aldrin.rs
@@ -182,6 +182,9 @@ impl PoolOperations for AldrinPool {
         _mint_in: &Pubkey,
         _mint_out: &Pubkey
     ) -> bool {
+        if self.pool_amounts.len() < self.get_mints().len() {
+            return false;
+        }
         for amount in self.pool_amounts.values() {
             if *amount == 0 { return false; }
         }
@@ -217,11 +220,15 @@ impl PoolOperations for AldrinPool {
         let id0 = &ids[0];
         let id1 = &ids[1];
         
-        let acc_data0 = &accounts[0].as_ref().unwrap().data;
-        let acc_data1 = &accounts[1].as_ref().unwrap().data;
+        let acc0 = accounts.get(0).and_then(|account| account.as_ref());
+        let acc1 = accounts.get(1).and_then(|account| account.as_ref());
+        let (Some(acc0), Some(acc1)) = (acc0, acc1) else {
+            self.pool_amounts.clear();
+            return;
+        };
 
-        let amount0 = unpack_token_account(acc_data0).amount as u128;
-        let amount1 = unpack_token_account(acc_data1).amount as u128;
+        let amount0 = unpack_token_account(&acc0.data).amount as u128;
+        let amount1 = unpack_token_account(&acc1.data).amount as u128;
 
         self.pool_amounts.insert(id0.clone(), amount0);
         self.pool_amounts.insert(id1.clone(), amount1);

--- a/client/src/pools/mercurial.rs
+++ b/client/src/pools/mercurial.rs
@@ -123,6 +123,9 @@ impl PoolOperations for MercurialPool {
         _mint_in: &Pubkey,
         _mint_out: &Pubkey
     ) -> bool {
+        if self.pool_amounts.len() < self.get_mints().len() {
+            return false;
+        }
         for amount in self.pool_amounts.values() {
             if *amount == 0 { return false; }
         }
@@ -148,11 +151,15 @@ impl PoolOperations for MercurialPool {
         let id0 = &ids[0];
         let id1 = &ids[1];
         
-        let acc_data0 = &accounts[0].as_ref().unwrap().data;
-        let acc_data1 = &accounts[1].as_ref().unwrap().data;
+        let acc0 = accounts.get(0).and_then(|account| account.as_ref());
+        let acc1 = accounts.get(1).and_then(|account| account.as_ref());
+        let (Some(acc0), Some(acc1)) = (acc0, acc1) else {
+            self.pool_amounts.clear();
+            return;
+        };
 
-        let amount0 = unpack_token_account(acc_data0).amount as u128;
-        let amount1 = unpack_token_account(acc_data1).amount as u128;
+        let amount0 = unpack_token_account(&acc0.data).amount as u128;
+        let amount1 = unpack_token_account(&acc1.data).amount as u128;
 
         self.pool_amounts.insert(id0.clone(), amount0);
         self.pool_amounts.insert(id1.clone(), amount1);

--- a/client/src/pools/orca.rs
+++ b/client/src/pools/orca.rs
@@ -148,6 +148,9 @@ impl PoolOperations for OrcaPool {
         _mint_in: &Pubkey,
         _mint_out: &Pubkey
     ) -> bool {
+        if self.pool_amounts.len() < self.get_mints().len() {
+            return false;
+        }
         for amount in self.pool_amounts.values() {
             if *amount == 0 { return false; }
         }
@@ -163,11 +166,15 @@ impl PoolOperations for OrcaPool {
         let id0 = &ids[0];
         let id1 = &ids[1];
         
-        let acc_data0 = &accounts[0].as_ref().unwrap().data;
-        let acc_data1 = &accounts[1].as_ref().unwrap().data;
+        let acc0 = accounts.get(0).and_then(|account| account.as_ref());
+        let acc1 = accounts.get(1).and_then(|account| account.as_ref());
+        let (Some(acc0), Some(acc1)) = (acc0, acc1) else {
+            self.pool_amounts.clear();
+            return;
+        };
 
-        let amount0 = unpack_token_account(acc_data0).amount as u128;
-        let amount1 = unpack_token_account(acc_data1).amount as u128;
+        let amount0 = unpack_token_account(&acc0.data).amount as u128;
+        let amount1 = unpack_token_account(&acc1.data).amount as u128;
 
         self.pool_amounts.insert(id0.clone(), amount0);
         self.pool_amounts.insert(id1.clone(), amount1);

--- a/client/src/pools/saber.rs
+++ b/client/src/pools/saber.rs
@@ -122,11 +122,15 @@ impl PoolOperations for SaberPool {
         let id0 = &ids[0];
         let id1 = &ids[1];
         
-        let acc_data0 = &accounts[0].as_ref().unwrap().data;
-        let acc_data1 = &accounts[1].as_ref().unwrap().data;
+        let acc0 = accounts.get(0).and_then(|account| account.as_ref());
+        let acc1 = accounts.get(1).and_then(|account| account.as_ref());
+        let (Some(acc0), Some(acc1)) = (acc0, acc1) else {
+            self.pool_amounts.clear();
+            return;
+        };
 
-        let amount0 = unpack_token_account(acc_data0).amount as u128;
-        let amount1 = unpack_token_account(acc_data1).amount as u128;
+        let amount0 = unpack_token_account(&acc0.data).amount as u128;
+        let amount1 = unpack_token_account(&acc1.data).amount as u128;
 
         self.pool_amounts.insert(id0.clone(), amount0);
         self.pool_amounts.insert(id1.clone(), amount1);
@@ -136,6 +140,9 @@ impl PoolOperations for SaberPool {
         _mint_in: &Pubkey,
         _mint_out: &Pubkey
     ) -> bool {
+        if self.pool_amounts.len() < self.get_mints().len() {
+            return false;
+        }
         for amount in self.pool_amounts.values() {
             if *amount == 0 { return false; }
         }

--- a/client/src/pools/serum.rs
+++ b/client/src/pools/serum.rs
@@ -256,14 +256,20 @@ impl PoolOperations for SerumPool {
             amount_out: 0,
         };
 
-        let market_acc = &self.accounts.as_ref().unwrap()[0];
-        let bids_acc = &self.accounts.as_ref().unwrap()[1];
-        let asks_acc = &self.accounts.as_ref().unwrap()[2];
+        let Some(accounts) = self.accounts.as_ref() else {
+            return 0;
+        };
+        let market_acc = accounts.get(0).and_then(|account| account.as_ref());
+        let bids_acc = accounts.get(1).and_then(|account| account.as_ref());
+        let asks_acc = accounts.get(2).and_then(|account| account.as_ref());
+        let (Some(market_acc), Some(bids_acc), Some(asks_acc)) = (market_acc, bids_acc, asks_acc) else {
+            return 0;
+        };
         
         // clone accounts for simulation (improve later?)
-        let market_acc = &mut market_acc.clone().unwrap();
-        let bid_acc = &mut bids_acc.clone().unwrap();
-        let ask_acc = &mut asks_acc.clone().unwrap();
+        let market_acc = &mut market_acc.clone();
+        let bid_acc = &mut bids_acc.clone();
+        let ask_acc = &mut asks_acc.clone();
 
         let market_acc_info = &account_info(&self.own_address.0, market_acc);
         let bids_acc = &account_info(&self.bids.0, bid_acc);
@@ -370,14 +376,20 @@ impl PoolOperations for SerumPool {
         _mint_out: &Pubkey
     ) -> bool {
 
-        let market_acc = &self.accounts.as_ref().unwrap()[0];
-        let bids_acc = &self.accounts.as_ref().unwrap()[1];
-        let asks_acc = &self.accounts.as_ref().unwrap()[2];
+        let Some(accounts) = self.accounts.as_ref() else {
+            return false;
+        };
+        let market_acc = accounts.get(0).and_then(|account| account.as_ref());
+        let bids_acc = accounts.get(1).and_then(|account| account.as_ref());
+        let asks_acc = accounts.get(2).and_then(|account| account.as_ref());
+        let (Some(market_acc), Some(bids_acc), Some(asks_acc)) = (market_acc, bids_acc, asks_acc) else {
+            return false;
+        };
         
         // clone accounts for simulation (improve later?)
-        let market_acc = &mut market_acc.clone().unwrap();
-        let bid_acc = &mut bids_acc.clone().unwrap();
-        let ask_acc = &mut asks_acc.clone().unwrap();
+        let market_acc = &mut market_acc.clone();
+        let bid_acc = &mut bids_acc.clone();
+        let ask_acc = &mut asks_acc.clone();
 
         let market_acc_info = &account_info(&self.own_address.0, market_acc);
         let bids_acc = &account_info(&self.bids.0, bid_acc);


### PR DESCRIPTION
## Summary

This patch turns missing pool update accounts into a route/pool-unavailable state instead of a panic.

It targets the failure pattern reported in #7 and related slice risk from #6:

- keep `get_multiple_accounts` results aligned as `Vec<Option<Account>>` instead of filtering out `None` before per-pool slicing;
- guard the main pool-account slice before indexing;
- make Mercurial, Aldrin, Orca, and Saber clear `pool_amounts` and return when a vault account is missing;
- make `can_trade` return `false` until all expected pool amounts exist;
- make Serum quote/can-trade paths return `0`/`false` when market/bid/ask accounts are missing instead of unwrapping.

The invariant is: incomplete public RPC account state must skip the route, not crash the arbitrage process.

## Notes

I could not run a full local `cargo check` on Windows because the repository contains historical `onchain-data/results/...` filenames that cannot be checked out on Windows. The patch was prepared through the GitHub object API and kept intentionally small.

No keys, funds, RPC writes, or live trading were used.

Closes #7.